### PR TITLE
Use `erlang:crc32/1` instead of `zlib:crc32/2`

### DIFF
--- a/src/egd_png.erl
+++ b/src/egd_png.erl
@@ -97,9 +97,9 @@ png_type(r8g8b8) -> ?TRUECOLOUR.
 
 create_chunk(Bin,Z) when is_list(Bin) ->
     create_chunk(list_to_binary(Bin),Z);
-create_chunk(Bin,Z) when is_binary(Bin) ->
+create_chunk(Bin,_Z) when is_binary(Bin) ->
     Sz = size(Bin)-4,
-    Crc = zlib:crc32(Z,Bin),
+    Crc = erlang:crc32(Bin),
     <<Sz:32,Bin/binary,Crc:32>>.
 
 % End tainted


### PR DESCRIPTION
See https://www.erlang.org/docs/26/man/zlib#crc32-2

While using your Gleam library `glidicon`, I ran into an Erlang warning during build and a crash at runtime. This is my first time working with Erlang code, so I may be missing some nuance here, but it doesn't crash anymore when `glidicon` calls it!